### PR TITLE
Remove unnecessary URL encoding when setting bg image

### DIFF
--- a/parallax.js
+++ b/parallax.js
@@ -99,7 +99,7 @@
     if (navigator.userAgent.match(/(iPod|iPhone|iPad)/)) {
       if (this.iosFix && !this.$element.is('img')) {
         this.$element.css({
-          backgroundImage: 'url(' + encodeURIComponent(this.imageSrc) + ')',
+          backgroundImage: 'url(' + this.imageSrc + ')',
           backgroundSize: 'cover',
           backgroundPosition: this.position
         });


### PR DESCRIPTION
this.imageSrc is not being set as URI component so this encoding just breaks URLs containing "/" and other common chars. The only URL char you'd would worry about would be `)` but that's a) extremely rare in an image URL, and b) would probably be URL encoded by the browser when it read the property.
