### PR TITLE
add destroy functionality

### DIFF
--- a/parallax.js
+++ b/parallax.js
@@ -311,6 +311,22 @@
           self.isBusy = false;
         });
       }
+    },
+    destroy: function(el){
+      var i,
+          parallaxElement = $(el).data('px.parallax');
+      parallaxElement.$mirror.remove();
+      for(i=0; i < this.sliders.length; i+=1){
+        if(this.sliders[i] == parallaxElement){
+          this.sliders.splice(i, 1);
+        }
+      }
+      $(el).data('px.parallax', false);
+      if(this.sliders.length === 0){
+        $(window).off('scroll.px.parallax resize.px.parallax load.px.parallax');
+        this.isReady = false;
+        Parallax.isSetup = false;
+      }
     }
   });
 
@@ -330,7 +346,11 @@
         $this.data('px.parallax', new Parallax(this, options));
       }
       if (typeof option == 'string') {
-        Parallax[option]();
+        if(option == 'destroy'){
+            Parallax['destroy'](this);
+        }else{
+          Parallax[option]();
+        }
       }
     })
   };


### PR DESCRIPTION
This pull request will add destroy functionality.
The functionality is used like this
$el.parallax(); //init
$el.parallax('destroy'); //destroy

If the destroyed element is the last parallax instance the events are cleared.