### PR TITLE
Add package.json for NPM package registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "parallax.js",
+  "version": "1.4.2",
+  "description": "Simple parallax scrolling effect inspired by Spotify.com implemented as a jQuery plugin",
+  "main": "parallax.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pixelcog/parallax.js.git"
+  },
+  "keywords": [
+    "parallax"
+  ],
+  "author": "Mike Greiling",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pixelcog/parallax.js/issues"
+  },
+  "homepage": "https://github.com/pixelcog/parallax.js#readme"
+}


### PR DESCRIPTION
It would be nice to be able to install Pixelcog via NPM to reduce the number of package managers involved in projects for those of us that don't want to use Bower.