### PR TITLE
add Class for own fix (when responsive images)

### DIFF
--- a/parallax.js
+++ b/parallax.js
@@ -99,6 +99,7 @@
           backgroundPosition: this.position
         });
       }
+      this.$element.addClass('fix ios-fix');
       return this;
     }
 
@@ -110,6 +111,7 @@
           backgroundPosition: this.position
         });
       }
+      this.$element.addClass('fix android-fix');
       return this;
     }
 


### PR DESCRIPTION
With use of responsive images this.imageSrc in iOS- and Adroid-fix
doesn’t grip. With particular class to this.$element script or css can
react to that…
- on «fix» in general or with «ios-fix»|«android-fix» in particular on
  type of OS.
  Will result in:
  <div class="parallax-window fix ios-fix">
  <div class="parallax-slider">
  <img src="/path/to/image.jpg" …“>
  </div>
  </div>
