### PR TITLE
Fix an error occurred only on mobile devices

### DIFF
--- a/parallax.js
+++ b/parallax.js
@@ -345,7 +345,9 @@
     destroy: function(el){
       var i,
           parallaxElement = $(el).data('px.parallax');
-      parallaxElement.$mirror.remove();
+      if (!!parallaxElement.$mirror) {
+        parallaxElement.$mirror.remove();
+      }
       for(i=0; i < this.sliders.length; i+=1){
         if(this.sliders[i] == parallaxElement){
           this.sliders.splice(i, 1);


### PR DESCRIPTION
Since the checking what agent is used has been added, `$mirror` property no longer available on mobile devices