### PR TITLE
typo fixed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Parallax.DEFAULTS = {
 These defaults can be changed easily, e.g.:
 ```javascript
 Parallax.DEFAULTS.speed = -.2;
-Parallax.DEFAULTS.afreRefresh = (instance) => { doSomethingWith(instance); };
+Parallax.DEFAULTS.afterRefresh = (instance) => { doSomethingWith(instance); };
 ```
 
 #### Data Attributes 


### PR DESCRIPTION
A simple typo was found when reading through. Fixed easily